### PR TITLE
fix: Correct paper code and data repo URL

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -395,7 +395,7 @@
   author       = {{Hance, Michael and Stark, Giordon}},
   publisher    = {GitHub},
   date         = {2022-01-01},
-  howpublished = {\url{https://github.com/scipp/mapyde-paper-data}},
+  howpublished = {\url{https://github.com/scipp-atlas/mapyde-paper-data}},
   journaltitle = {GitHub repository},
   title        = {User files for running \mapyde to reproduce reinterpret ATLAS Compressed SUSY searches},
 }


### PR DESCRIPTION
This PR corrects a 404 error in the references for https://github.com/scipp-atlas/mapyde-paper-data.